### PR TITLE
Adding my own version of polish to the internals.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ func main() {
 	options := hmacauth.Options{
 		SignedHeaders:       []string{"Content-MD5", "Content-Type"},
 		SecretKey:           func(apiKey string) string { return "secret" },
-		SignatureExpiration: 300,
+		SignatureExpiresIn: 300 * time.Second,
 	}
 
 	m.Use(hmacauth.HMACAuth(options))
@@ -61,8 +61,8 @@ will be sorted before being evaluated.
 A function that will return a secret key to use for a given api key. If a value
 is not provided, a `panic` will be raised when starting the server.
 
-* ### SignatureExpiration: `int32` *Optional*
-An integer representing the maximum number of seconds that a signature is valid
+* ### SignatureExpiresIn: `time.Duration` *Optional*
+An duration representing the maximum length of time that a signature is valid
 for.
 
 Once you've created an instance of `Options` you can pass it to `HMACAuth` to

--- a/hmacauth.go
+++ b/hmacauth.go
@@ -16,24 +16,41 @@ import (
 type middleware func(http.ResponseWriter, *http.Request)
 type keyLocator func(string) string
 
+const maxNegativeFloat time.Duration = -10 * time.Second
+
 type Options struct {
-	SignedHeaders       []string
-	SecretKey           keyLocator
-	SignatureExpiration int32
+	SignedHeaders      []string
+	SecretKey          keyLocator
+	SignatureExpiresIn time.Duration
 }
 
-type AuthBits struct {
+type HMACAuthError struct {
+	Message string
+}
+
+func (e HMACAuthError) Error() string {
+	return e.Message
+}
+
+type authBits struct {
 	APIKey          string
 	Signature       string
 	TimestampString string
 	Timestamp       time.Time
 }
 
-func (ab AuthBits) IsValid() bool {
+func (ab *authBits) IsValid() bool {
 	return ab.APIKey != "" &&
 		ab.Signature != "" &&
-		ab.TimestampString != "" &&
 		!ab.Timestamp.IsZero()
+}
+
+func (ab *authBits) SetTimestamp(isoTime string) (err error) {
+	ab.Timestamp, err = time.Parse(time.RFC3339, isoTime)
+	if err == nil {
+		ab.TimestampString = isoTime
+	}
+	return
 }
 
 func HMACAuth(options Options) middleware {
@@ -43,39 +60,28 @@ func HMACAuth(options Options) middleware {
 	}
 
 	return func(res http.ResponseWriter, req *http.Request) {
-		authHeader := req.Header.Get("Authorization")
-		if authHeader == "" {
-			http.Error(res, "Authorization Header Not Supplied", 401)
-			return
+		var (
+			err error
+			ab  *authBits
+		)
+
+		if ab, err = parseAuthHeader(req.Header.Get("Authorization")); err == nil {
+			if err = validateTimestamp(ab.Timestamp, &options); err == nil {
+				var sts string
+				if sts, err = stringToSign(req, &options, ab.TimestampString); err == nil {
+					if sk := options.SecretKey(ab.APIKey); sk != "" {
+						if ab.Signature != signString(sts, sk) {
+							err = HMACAuthError{"Invalid Signature"}
+						}
+					} else {
+						err = HMACAuthError{"Invalid APIKey"}
+					}
+				}
+			}
 		}
 
-		authBits, err := parseAuthHeader(authHeader)
 		if err != nil {
 			http.Error(res, err.Error(), 401)
-			return
-		}
-
-		if timeoutErr := validateTimestamp(authBits.Timestamp, &options); timeoutErr != nil {
-			http.Error(res, err.Error(), 401)
-			return
-		}
-
-		str, err := stringToSign(req, &options, authBits.TimestampString)
-		if err != nil {
-			http.Error(res, err.Error(), 401)
-			return
-		}
-
-		secretKey := options.SecretKey(authBits.APIKey)
-		if secretKey == "" {
-			http.Error(res, "Invalid APIKey", 401)
-			return
-		}
-
-		sig := signString(str, secretKey)
-		if sig != authBits.Signature {
-			http.Error(res, "Invalid Signature", 401)
-			return
 		}
 	}
 }
@@ -114,60 +120,56 @@ func stringToSign(req *http.Request, options *Options, timestamp string) (string
 	return buffer.String(), nil
 }
 
-func parseAuthHeader(header string) (AuthBits, error) {
+func parseAuthHeader(header string) (*authBits, error) {
+	if header == "" {
+		return nil, HMACAuthError{"Authorization Header Not Supplied"}
+	}
 
-	var ab AuthBits
-
+	ab := new(authBits)
 	parts := strings.Split(header, ",")
 	for _, part := range parts {
 		kv := strings.SplitN(strings.Trim(part, " "), "=", 2)
 		if kv[0] == "APIKey" {
 			if ab.APIKey != "" {
-				return repeatedParameter(kv[0])
+				return nil, repeatedParameterError(kv[0])
 			}
 			ab.APIKey = kv[1]
 		} else if kv[0] == "Signature" {
 			if ab.Signature != "" {
-				return repeatedParameter(kv[0])
+				return nil, repeatedParameterError(kv[0])
 			}
 			ab.Signature = kv[1]
 		} else if kv[0] == "Timestamp" {
 			if !ab.Timestamp.IsZero() {
-				return repeatedParameter(kv[0])
+				return nil, repeatedParameterError(kv[0])
 			}
-			t, err := time.Parse(time.RFC3339, kv[1])
-			if err != nil {
-				return parseError("Invalid timestamp. Requires RFC3339 format.")
+			if ab.SetTimestamp(kv[1]) != nil {
+				return nil, HMACAuthError{"Invalid timestamp. Requires RFC3339 format."}
 			}
-			ab.Timestamp = t
-			ab.TimestampString = kv[1]
 		} else {
-			return parseError("Invalid parameter in header string")
+			return nil, HMACAuthError{"Invalid parameter in header string"}
 		}
 	}
 
 	if !ab.IsValid() {
-		return parseError("Missing parameter in header string")
+		return nil, HMACAuthError{"Missing parameter in header string"}
 	}
 
 	return ab, nil
 }
 
-func parseError(s string) (AuthBits, error) {
-	return AuthBits{}, errors.New(s)
-}
-
-func repeatedParameter(paramName string) (AuthBits, error) {
-	return parseError(fmt.Sprintf("Repeated parameter: %q in header string", paramName))
+func repeatedParameterError(paramName string) error {
+	return HMACAuthError{fmt.Sprintf("Repeated parameter: %q in header string", paramName)}
 }
 
 func validateTimestamp(ts time.Time, options *Options) error {
+	reqTime := time.Since(ts)
 
 	diffSeconds := time.Now().Sub(ts).Seconds()
 
-	// Allow for about 10 seconds of difference, some servers are
+	// Allow for about `maxNegativeFloat` of difference, some servers are
 	// ahead and some are behind
-	if diffSeconds < (-10.0) {
+	if reqTime < maxNegativeFloat {
 		return errors.New("Timestamp out of range")
 	}
 
@@ -175,8 +177,8 @@ func validateTimestamp(ts time.Time, options *Options) error {
 	if diffSeconds < 0.0 {
 		diffSeconds = 0.0
 	}
-	if options.SignatureExpiration != 0 {
-		if diffSeconds > float64(options.SignatureExpiration) {
+	if options.SignatureExpiresIn != 0 {
+		if reqTime > options.SignatureExpiresIn {
 			return errors.New("Signature expired")
 		}
 	}

--- a/hmacauth.go
+++ b/hmacauth.go
@@ -165,18 +165,12 @@ func repeatedParameterError(paramName string) error {
 func validateTimestamp(ts time.Time, options *Options) error {
 	reqTime := time.Since(ts)
 
-	diffSeconds := time.Now().Sub(ts).Seconds()
-
 	// Allow for about `maxNegativeFloat` of difference, some servers are
 	// ahead and some are behind
 	if reqTime < maxNegativeFloat {
 		return errors.New("Timestamp out of range")
 	}
 
-	// do our best to normalize
-	if diffSeconds < 0.0 {
-		diffSeconds = 0.0
-	}
 	if options.SignatureExpiresIn != 0 {
 		if reqTime > options.SignatureExpiresIn {
 			return errors.New("Signature expired")

--- a/hmacauth.go
+++ b/hmacauth.go
@@ -163,16 +163,16 @@ func repeatedParameterError(paramName string) error {
 }
 
 func validateTimestamp(ts time.Time, options *Options) error {
-	reqTime := time.Since(ts)
+	reqAge := time.Since(ts)
 
 	// Allow for about `maxNegativeFloat` of difference, some servers are
 	// ahead and some are behind
-	if reqTime < maxNegativeFloat {
+	if reqAge < maxNegativeFloat {
 		return errors.New("Timestamp out of range")
 	}
 
 	if options.SignatureExpiresIn != 0 {
-		if reqTime > options.SignatureExpiresIn {
+		if reqAge > options.SignatureExpiresIn {
 			return errors.New("Signature expired")
 		}
 	}

--- a/hmacauth_test.go
+++ b/hmacauth_test.go
@@ -59,27 +59,20 @@ func Test_validateTimeout_past_no_timeout_set(t *testing.T) {
 
 func Test_validateTimeout_expired(t *testing.T) {
 	past := secondsAgo(300)
-	err := validateTimestamp(past, &Options{SignatureExpiration: 100})
+	err := validateTimestamp(past, &Options{SignatureExpiresIn: 100 * time.Second})
 	refute(t, err, nil)
 	expect(t, err.Error(), "Signature expired")
 }
 
 func Test_validateTimeout_past_not_expired(t *testing.T) {
 	past := secondsAgo(30)
-	err := validateTimestamp(past, &Options{SignatureExpiration: 100})
+	err := validateTimestamp(past, &Options{SignatureExpiresIn: 100 * time.Second})
 	expect(t, err, nil)
-}
-
-func Test_parseError(t *testing.T) {
-	errString := "This is an error"
-	_, err := parseError(errString)
-	refute(t, err, nil)
-	expect(t, err.Error(), errString)
 }
 
 func Test_repeatedParameter(t *testing.T) {
 	errString := "Repeated parameter: \"Boo\" in header string"
-	_, err := repeatedParameter("Boo")
+	err := repeatedParameterError("Boo")
 	refute(t, err, nil)
 	expect(t, err.Error(), errString)
 }
@@ -190,7 +183,6 @@ func Test_stringToSign_with_ordered_headers(t *testing.T) {
 	expect(t, expectedStr, str)
 }
 
-
 func Test_stringToSign_missing_required_header(t *testing.T) {
 	req, _ := http.NewRequest("GET", "http://testhost.test/some/path?key=value&more=stuff", nil)
 	req.Header.Add("X-Test1", "12345678")
@@ -254,7 +246,7 @@ func Test_HMACAuth_bad_api_key(t *testing.T) {
 func Test_HMACAuth_incorrect_header_order_in_string_to_sign(t *testing.T) {
 	options := Options{
 		SignedHeaders: []string{"A-Test", "B-Test"},
-		SecretKey: func(apiKey string) string {return "secret"},
+		SecretKey:     func(apiKey string) string { return "secret" },
 	}
 	middlewareFunc := HMACAuth(options)
 
@@ -282,7 +274,6 @@ func Test_HMACAuth_incorrect_header_order_in_string_to_sign(t *testing.T) {
 	expect(t, w.Code, 401)
 	expect(t, "Invalid Signature\n", w.Body.String())
 }
-
 
 func Test_HMACAuth_bad_signature(t *testing.T) {
 	options := Options{


### PR DESCRIPTION
- Using `time.Duration` instead of an `int32` to represent how long signatures are good for.
- Created own Error type.
- Other stylistic flourishes. 
